### PR TITLE
Fix modal event listener conflicts by standardizing portal root cleanup

### DIFF
--- a/HTML/chat_customizer_popup.html
+++ b/HTML/chat_customizer_popup.html
@@ -1,181 +1,398 @@
 <div id="headlessui-portal-root">
-    <div data-headlessui-portal=""><button type="button" data-headlessui-focus-guard="true" aria-hidden="true"
-            style="position: fixed; top: 1px; left: 1px; width: 1px; height: 0px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"></button>
+  <div data-headlessui-portal="">
+    <button
+      type="button"
+      data-headlessui-focus-guard="true"
+      aria-hidden="true"
+      style="
+        position: fixed;
+        top: 1px;
+        left: 1px;
+        width: 1px;
+        height: 0px;
+        padding: 0px;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0px, 0px, 0px, 0px);
+        white-space: nowrap;
+        border-width: 0px;
+      "
+    ></button>
 
-        <div class="relative z-50" id="headlessui-dialog-:r1f:" role="dialog" aria-modal="true"
-            data-headlessui-state="open" aria-labelledby="headlessui-dialog-title-:r1h:">
-            <div class="fixed inset-0 bg-backdrop transition-opacity opacity-100"></div>
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0">
-                    <div class="relative w-full overflow-y-auto rounded-lg bg-secondaryBg shadow-xl transition-all sm:my-8 sm:max-w-2xl opacity-100 translate-y-0 sm:scale-100"
-                        id="chat-customizer-ui-popup" data-headlessui-state="open"><button
-                            class="absolute right-4 top-4 z-20 p-2 text-primaryText" id="close-button"><svg
-                                xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                stroke-width="1.5" stroke="red" aria-hidden="true" data-slot="icon"
-                                class="h-5 w-5">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12">
-                                </path>
-                            </svg></button>
-                        <div class="bg-secondaryBg p-6">
-                            <h3 class="font-bold text-primaryText" id="headlessui-dialog-title-:r1h:"
-                                data-headlessui-state="open">Chat Customization</h3>
-                            <div class="mt-8 text-primaryText">
-                                <div class="flex items-center justify-between">
-                                    <p class="font-bold text-primaryText pb-3">Character Settings</p><button id="character-settings-reset-button"
-                                        class="flex items-center gap-1 text-xs text-secondaryText hover:text-primaryBtn"><svg
-                                            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-                                            aria-hidden="true" data-slot="icon" class="h-4 w-4">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"></path>
-                                        </svg>
-                                        <p>Reset</p>
-                                    </button>
-                                </div>
-                                <div class="flex items-center">
-                                    <div class="flex items-center pb-1 font-medium text-sm">Name</div>
-                                </div>
-                                <div class="relative pb-3"><input
-                                        id="name-input"
-                                        placeholder="Enter a new name for character (blank for default)"
-                                        class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm">
-                                </div>
-                                <div class="flex items-center gap-4 pb-3">
-                                    <div class="font-medium text-sm">Name Color</div>
-                                    <div class="relative"><input type="color" id="name-color-input" value="#ffffff" class="relative h-10 rounded-md bg-tertiaryBg"></div>
-                                </div>
-                                <div>
-                                </div>
-                                <div class="flex items-center">
-                                    <div class="pb-1 font-medium text-sm">Image</div>
-                                </div>
-                                <div class="relative pb-3"><input id="character-image-url-input" type="url" placeholder="Enter a URL"
-                                        class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm">
-                                </div>
-                                <div class="relative pb-3"><input id="character-image-file-input" type="file" placeholder="Enter a File Path"
-                                        class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm">
-                                </div>
-
-                            </div>
-
-                            <hr class="my-6 border-t border-separator/10">
-
-                            <div class="flex items-center justify-between">
-                                <p class="font-bold text-primaryText pb-3">Background</p><button id="background-reset-button"
-                                    class="flex items-center gap-1 text-xs text-secondaryText hover:text-primaryBtn"><svg
-                                        xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                        stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon"
-                                        class="h-4 w-4">
-                                        <path stroke-linecap="round" stroke-linejoin="round"
-                                            d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"></path>
-                                    </svg>
-                                    <p>Reset</p>
-                                </button>
-                            </div>
-
-                            <div class="text-primaryText">
-                                <div class="flex pb-3">
-                                    <div class="w-full">
-                                        <div class="relative pb-2"><input id="bg-url-input" type="url" placeholder="Enter a URL"
-                                                class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm ">
-                                        </div>
-                                        <div class="relative"><input id="bg-file-input" type="file" placeholder="Enter a File Path"
-                                                class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm">
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <hr class="my-6 border-t border-separator/10">
-
-                                <div class="flex items-center justify-between">
-                                    <p class="font-bold text-primaryText pb-3">Chat Colors</p><button id="color-reset-button"
-                                        class="flex items-center gap-1 text-xs text-secondaryText hover:text-primaryBtn"><svg
-                                            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                            stroke-width="1.5" stroke="currentColor" aria-hidden="true"
-                                            data-slot="icon" class="h-4 w-4">
-                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"></path>
-                                        </svg>
-                                        <p>Reset</p>
-                                    </button>
-                                </div>
-                                
-                                <div class="mt-6 text-primaryText content-center grid grid-cols-2 grid-rows-3 gap-4">
-
-                                    <div class="flex items-center justify-between">
-                                        <div class="font-medium text-sm">Character Narration</div>
-                                        <div class="flex"><input id="character-narration-color-input" type="color" value="#b0d8fB"
-                                                class="h-10 rounded-md bg-tertiaryBg"></div>
-                                    </div>
-                                    <div class="flex items-center justify-between">
-                                        <div class="font-medium text-sm">User Name</div>
-                                        <div><input id="user-name-color-input" type="color" value="#000000" class="h-10 rounded-md bg-tertiaryBg"></div>
-                                    </div>
-                        
-                                    <div class="flex items-center justify-between">
-                                        <div class="font-medium text-sm">Character Chat</div>
-                                        <div class="flex"><input id="character-chat-color-input" type="color" value="#ffffff"
-                                                class="h-10 rounded-md bg-tertiaryBg"></div>
-                                    </div>
-                                    
-                                    <div class="flex items-center justify-between">
-                                                <div class="font-medium text-sm">User Chat</div>
-                                        <div class="flex"><input id="user-chat-color-input"type="color" value="#000000"
-                                                class="h-10 rounded-md bg-tertiaryBg "></div>
-                                    </div>
-                        
-                                    <div class="flex items-center justify-between">
-                                        <div class="font-medium text-sm">Character Chat Bg</div>
-                                        <div class="flex"><input id="character-chat-bg-color-input" type="color" value="#000000"
-                                                class="h-10 rounded-md bg-tertiaryBg "></div>
-                                    </div>
-                                    <div class="flex items-center justify-between">
-                                        <div class="font-medium text-sm">User Chat Bg</div>
-                                        <div ><input id="user-chat-bg-color-input"type="color" value="#ffffff"
-                                                class="h-10 rounded-md bg-tertiaryBg"></div>
-                                    </div>
-
-                                </div>
-
-                            </div>
-                            <hr class="my-6 border-t border-separator/10">
-
-                            <div class="flex items-center gap-2 transition-opacity justify-evenly">
-
-                                <div class="flex gap-2"><input
-                                        class="flex h-7 w-7 shrink-0 cursor-pointer appearance-none justify-center rounded bg-tertiaryBg checked:before:flex checked:before:items-center checked:before:justify-center checked:before:text-primaryText checked:before:content-[url(/assets/images/checkmark.svg)]"
-                                        id="apply-to-all-checkbox" type="checkbox"><label
-                                        class="inline-flex items-center text-sm font-semibold text-primaryText">Apply Color Scheme Universally</label></div>
-                            
-                                
-                                <div class="flex gap-2"><input
-                                        class="flex h-7 w-7 shrink-0 cursor-pointer appearance-none justify-center rounded bg-tertiaryBg checked:before:flex checked:before:items-center checked:before:justify-center checked:before:text-primaryText checked:before:content-[url(/assets/images/checkmark.svg)]"
-                                        id="character-theme-checkbox" type="checkbox" checked=""><label
-                                        class="inline-flex items-center text-sm font-semibold text-primaryText">Set as Character Theme</label></div>
-                                <div class="flex justify-center my-4">
-                                    <span class="text-secondaryText font-medium text-center">[If both unchecked, theme will be applied to current chat only!]</span>
-                                </div>
-                            </div>
-
-                            <hr class="my-6 border-t border-separator/10">
-                            <button type="button"
-                                id="save-button"
-                                class="inline-flex justify-center items-center rounded-xl border px-4 text-lg font-bold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 mt-6 h-11 w-full border-transparent bg-primaryBtn text-darkText focus:ring-primaryBtn disabled:opacity-50">Save</button>
-                            <div class="flex items-center gap-2 transition-opacity justify-evenly">
-                                <button type="button"
-                                    id="delete-current-page-style-button"
-                                    class="inline-flex justify-center items-center rounded-xl border px-4 text-lg font-bold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 mt-3 h-11 w-full border-transparent bg-red-500 text-white hover:bg-red-600 focus:ring-red-500 disabled:opacity-50">Delete <svg class="w-6 h-6 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
-                                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 7h14m-9 3v8m4-8v8M10 3h4a1 1 0 0 1 1 1v3H9V4a1 1 0 0 1 1-1ZM6 7h12v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V7Z"/>
-                                    </svg>
-                                    </button>
-                                <button type="button"
-                                    id="delete-all-character-styles-button"
-                                    class="inline-flex justify-center items-center rounded-xl border px-4 text-lg font-bold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 mt-3 h-11 w-full border-transparent bg-red-500 text-white hover:bg-red-600 focus:ring-red-500 disabled:opacity-50">Delete (All)</button>
-                            </div>
-                        </div>
-                    </div>
+    <div
+      class="relative z-50"
+      id="headlessui-dialog-:r1g:"
+      role="dialog"
+      aria-modal="true"
+      data-headlessui-state="open"
+      aria-labelledby="headlessui-dialog-title-:r1h:"
+    >
+      <div
+        class="fixed inset-0 bg-backdrop transition-opacity opacity-100"
+      ></div>
+      <div class="fixed inset-0 z-10 overflow-y-auto">
+        <div
+          class="flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0"
+        >
+          <div
+            class="relative w-full overflow-y-auto rounded-lg bg-secondaryBg shadow-xl transition-all sm:my-8 sm:max-w-2xl opacity-100 translate-y-0 sm:scale-100"
+            id="chat-customizer-ui-popup"
+            data-headlessui-state="open"
+          >
+            <button
+              class="absolute right-4 top-4 z-20 p-2 text-primaryText"
+              id="close-button"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="red"
+                aria-hidden="true"
+                data-slot="icon"
+                class="h-5 w-5"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M6 18 18 6M6 6l12 12"
+                ></path>
+              </svg>
+            </button>
+            <div class="bg-secondaryBg p-6">
+              <h3
+                class="font-bold text-primaryText"
+                id="headlessui-dialog-title-:r1h:"
+                data-headlessui-state="open"
+              >
+                Chat Customization
+              </h3>
+              <div class="mt-8 text-primaryText">
+                <div class="flex items-center justify-between">
+                  <p class="font-bold text-primaryText pb-3">
+                    Character Settings
+                  </p>
+                  <button
+                    id="character-settings-reset-button"
+                    class="flex items-center gap-1 text-xs text-secondaryText hover:text-primaryBtn"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="1.5"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                      data-slot="icon"
+                      class="h-4 w-4"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"
+                      ></path>
+                    </svg>
+                    <p>Reset</p>
+                  </button>
                 </div>
+                <div class="flex items-center">
+                  <div class="flex items-center pb-1 font-medium text-sm">
+                    Name
+                  </div>
+                </div>
+                <div class="relative pb-3">
+                  <input
+                    id="name-input"
+                    placeholder="Enter a new name for character (blank for default)"
+                    class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm"
+                  />
+                </div>
+                <div class="flex items-center gap-4 pb-3">
+                  <div class="font-medium text-sm">Name Color</div>
+                  <div class="relative">
+                    <input
+                      type="color"
+                      id="name-color-input"
+                      value="#ffffff"
+                      class="relative h-10 rounded-md bg-tertiaryBg"
+                    />
+                  </div>
+                </div>
+                <div></div>
+                <div class="flex items-center">
+                  <div class="pb-1 font-medium text-sm">Image</div>
+                </div>
+                <div class="relative pb-3">
+                  <input
+                    id="character-image-url-input"
+                    type="url"
+                    placeholder="Enter a URL"
+                    class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm"
+                  />
+                </div>
+                <div class="relative pb-3">
+                  <input
+                    id="character-image-file-input"
+                    type="file"
+                    placeholder="Enter a File Path"
+                    class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm"
+                  />
+                </div>
+              </div>
+
+              <hr class="my-6 border-t border-separator/10" />
+
+              <div class="flex items-center justify-between">
+                <p class="font-bold text-primaryText pb-3">Background</p>
+                <button
+                  id="background-reset-button"
+                  class="flex items-center gap-1 text-xs text-secondaryText hover:text-primaryBtn"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke-width="1.5"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                    data-slot="icon"
+                    class="h-4 w-4"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"
+                    ></path>
+                  </svg>
+                  <p>Reset</p>
+                </button>
+              </div>
+
+              <div class="text-primaryText">
+                <div class="flex pb-3">
+                  <div class="w-full">
+                    <div class="relative pb-2">
+                      <input
+                        id="bg-url-input"
+                        type="url"
+                        placeholder="Enter a URL"
+                        class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm"
+                      />
+                    </div>
+                    <div class="relative">
+                      <input
+                        id="bg-file-input"
+                        type="file"
+                        placeholder="Enter a File Path"
+                        class="relative h-10 w-full rounded-md bg-tertiaryBg px-2 pr-10 text-start text-sm"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <hr class="my-6 border-t border-separator/10" />
+
+                <div class="flex items-center justify-between">
+                  <p class="font-bold text-primaryText pb-3">Chat Colors</p>
+                  <button
+                    id="color-reset-button"
+                    class="flex items-center gap-1 text-xs text-secondaryText hover:text-primaryBtn"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="1.5"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                      data-slot="icon"
+                      class="h-4 w-4"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"
+                      ></path>
+                    </svg>
+                    <p>Reset</p>
+                  </button>
+                </div>
+
+                <div
+                  class="mt-6 text-primaryText content-center grid grid-cols-2 grid-rows-3 gap-4"
+                >
+                  <div class="flex items-center justify-between">
+                    <div class="font-medium text-sm">Character Narration</div>
+                    <div class="flex">
+                      <input
+                        id="character-narration-color-input"
+                        type="color"
+                        value="#b0d8fB"
+                        class="h-10 rounded-md bg-tertiaryBg"
+                      />
+                    </div>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <div class="font-medium text-sm">User Name</div>
+                    <div>
+                      <input
+                        id="user-name-color-input"
+                        type="color"
+                        value="#000000"
+                        class="h-10 rounded-md bg-tertiaryBg"
+                      />
+                    </div>
+                  </div>
+
+                  <div class="flex items-center justify-between">
+                    <div class="font-medium text-sm">Character Chat</div>
+                    <div class="flex">
+                      <input
+                        id="character-chat-color-input"
+                        type="color"
+                        value="#ffffff"
+                        class="h-10 rounded-md bg-tertiaryBg"
+                      />
+                    </div>
+                  </div>
+
+                  <div class="flex items-center justify-between">
+                    <div class="font-medium text-sm">User Chat</div>
+                    <div class="flex">
+                      <input
+                        id="user-chat-color-input"
+                        type="color"
+                        value="#000000"
+                        class="h-10 rounded-md bg-tertiaryBg"
+                      />
+                    </div>
+                  </div>
+
+                  <div class="flex items-center justify-between">
+                    <div class="font-medium text-sm">Character Chat Bg</div>
+                    <div class="flex">
+                      <input
+                        id="character-chat-bg-color-input"
+                        type="color"
+                        value="#000000"
+                        class="h-10 rounded-md bg-tertiaryBg"
+                      />
+                    </div>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <div class="font-medium text-sm">User Chat Bg</div>
+                    <div>
+                      <input
+                        id="user-chat-bg-color-input"
+                        type="color"
+                        value="#ffffff"
+                        class="h-10 rounded-md bg-tertiaryBg"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <hr class="my-6 border-t border-separator/10" />
+
+              <div
+                class="flex items-center gap-2 transition-opacity justify-evenly"
+              >
+                <div class="flex gap-2">
+                  <input
+                    class="flex h-7 w-7 shrink-0 cursor-pointer appearance-none justify-center rounded bg-tertiaryBg checked:before:flex checked:before:items-center checked:before:justify-center checked:before:text-primaryText checked:before:content-[url(/assets/images/checkmark.svg)]"
+                    id="apply-to-all-checkbox"
+                    type="checkbox"
+                  /><label
+                    class="inline-flex items-center text-sm font-semibold text-primaryText"
+                    >Apply Color Scheme Universally</label
+                  >
+                </div>
+
+                <div class="flex gap-2">
+                  <input
+                    class="flex h-7 w-7 shrink-0 cursor-pointer appearance-none justify-center rounded bg-tertiaryBg checked:before:flex checked:before:items-center checked:before:justify-center checked:before:text-primaryText checked:before:content-[url(/assets/images/checkmark.svg)]"
+                    id="character-theme-checkbox"
+                    type="checkbox"
+                    checked=""
+                  /><label
+                    class="inline-flex items-center text-sm font-semibold text-primaryText"
+                    >Set as Character Theme</label
+                  >
+                </div>
+                <div class="flex justify-center my-4">
+                  <span class="text-secondaryText font-medium text-center"
+                    >[If both unchecked, theme will be applied to current chat
+                    only!]</span
+                  >
+                </div>
+              </div>
+
+              <hr class="my-6 border-t border-separator/10" />
+              <button
+                type="button"
+                id="save-button"
+                class="inline-flex justify-center items-center rounded-xl border px-4 text-lg font-bold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 mt-6 h-11 w-full border-transparent bg-primaryBtn text-darkText focus:ring-primaryBtn disabled:opacity-50"
+              >
+                Save
+              </button>
+              <div
+                class="flex items-center gap-2 transition-opacity justify-evenly"
+              >
+                <button
+                  type="button"
+                  id="delete-current-page-style-button"
+                  class="inline-flex justify-center items-center rounded-xl border px-4 text-lg font-bold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 mt-3 h-11 w-full border-transparent bg-red-500 text-white hover:bg-red-600 focus:ring-red-500 disabled:opacity-50"
+                >
+                  Delete
+                  <svg
+                    class="w-6 h-6 text-gray-800 dark:text-white"
+                    aria-hidden="true"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M5 7h14m-9 3v8m4-8v8M10 3h4a1 1 0 0 1 1 1v3H9V4a1 1 0 0 1 1-1ZM6 7h12v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V7Z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  id="delete-all-character-styles-button"
+                  class="inline-flex justify-center items-center rounded-xl border px-4 text-lg font-bold shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 mt-3 h-11 w-full border-transparent bg-red-500 text-white hover:bg-red-600 focus:ring-red-500 disabled:opacity-50"
+                >
+                  Delete (All)
+                </button>
+              </div>
             </div>
+          </div>
         </div>
-        <button type="button" data-headlessui-focus-guard="true" aria-hidden="true"
-            style="position: fixed; top: 1px; left: 1px; width: 1px; height: 0px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-width: 0px;"></button>
+      </div>
     </div>
+    <button
+      type="button"
+      data-headlessui-focus-guard="true"
+      aria-hidden="true"
+      style="
+        position: fixed;
+        top: 1px;
+        left: 1px;
+        width: 1px;
+        height: 0px;
+        padding: 0px;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0px, 0px, 0px, 0px);
+        white-space: nowrap;
+        border-width: 0px;
+      "
+    ></button>
+  </div>
 </div>

--- a/HTML/image_viewer_popup.html
+++ b/HTML/image_viewer_popup.html
@@ -25,7 +25,7 @@
       role="dialog"
       aria-modal="true"
       data-headlessui-state="open"
-      aria-labelledby="headlessui-dialog-title-:r1h:"
+      aria-labelledby="headlessui-dialog-title-:r1i:"
     >
       <div
         class="fixed inset-0 bg-backdrop transition-opacity opacity-100" id="image-viewer-overlay"

--- a/JS/chat_customizer_popup.js
+++ b/JS/chat_customizer_popup.js
@@ -300,14 +300,23 @@ function handleMutations(mutationsList) {
 function initializeCloseButtonEventHandler(form, formBody) {
     console.log(formBody);
     const closeModal = () => {
-        // document.documentElement.style.cssText = '';
+        // Reset document styles
+        document.documentElement.style.overflow = '';
+        document.documentElement.style.paddingRight = '';
 
         let main = document.querySelector('body > main');
-        main.setAttribute('aria-hidden', 'false');
-        main.removeAttribute('inert');
+        if (main) {
+            main.setAttribute('aria-hidden', 'false');
+            main.removeAttribute('inert');
+        }
 
-        // form.style.display = 'none'; // or 'hidden' or 'unset' depending on your CSS
-        form.remove();
+        // Remove the modal by removing the portal root element
+        /** @type {HTMLElement|null} */
+        const portalRoot = document.getElementById('headlessui-portal-root');
+        if (portalRoot) {
+            portalRoot.remove();
+        }
+        
         document.removeEventListener('click', handleClickOutside);
 
     };

--- a/JS/image_viewer_popup.js
+++ b/JS/image_viewer_popup.js
@@ -52,29 +52,15 @@ function closeImageViewerModal() {
             main.removeAttribute('inert');
         }
 
-        // Target the correct overlay based on the actual DOM structure
-        // The overlay has id="image-viewer-overlay" and is a sibling to our currentViewer
-        /** @type {HTMLElement|null} */
-        const overlay = document.getElementById('image-viewer-overlay');
-        /** @type {HTMLElement|null} */
-        const dialogContainer = document.getElementById('headlessui-dialog-:r1f:') ||
-            (ImageViewerCache.currentViewer && ImageViewerCache.currentViewer.closest('[role="dialog"]'));
+        // Reset document styles that were set when opening the modal
+        document.documentElement.style.overflow = '';
+        document.documentElement.style.paddingRight = '';
+
+        // Remove the modal by removing the portal root element
         /** @type {HTMLElement|null} */
         const portalRoot = document.getElementById('headlessui-portal-root');
-
-        // Remove the entire modal structure - prefer the most specific container first
-        if (dialogContainer) {
-            dialogContainer.remove();
-        } else if (portalRoot) {
+        if (portalRoot) {
             portalRoot.remove();
-        } else if (overlay) {
-            // Fallback: remove overlay and try to find parent container
-            overlay.remove();
-            /** @type {HTMLElement|null} */
-            const container = ImageViewerCache.currentViewer && ImageViewerCache.currentViewer.closest('.fixed');
-            if (container) {
-                container.remove();
-            }
         }
 
         // Clean up event listeners

--- a/JS/utils.js
+++ b/JS/utils.js
@@ -121,7 +121,7 @@ async function addMenuItem(targetElement, itemId, resourceName) {
 function addCustomizeChatForm(itemId, resourceName) {
     console.log("Adding chat customizer form.");
     if (document.getElementById(itemId)) {
-        let form = document.querySelector('#headlessui-portal-root');
+        let portalRoot = document.querySelector('#headlessui-portal-root');
         let main = document.querySelector('body > main');
         
         // yodayo does this by default so I'm just mimicing it
@@ -129,10 +129,19 @@ function addCustomizeChatForm(itemId, resourceName) {
         document.documentElement.style.paddingRight = '1px';
 
         // To allow interaction with elements below the form
-        main.setAttribute('aria-hidden', 'true');
-        main.setAttribute('inert', '');
+        if (main) {
+            main.setAttribute('aria-hidden', 'true');
+            main.setAttribute('inert', '');
+        }
         
-        form.style.display = 'block';    
+        if (portalRoot) {
+            portalRoot.style.display = 'block';    
+        } else {
+            // Portal root doesn't exist, create new form
+            renderHTMLFromFile(resourceName).then(chatCustomizerForm => {
+                document.body.appendChild(chatCustomizerForm);
+            });
+        }
 
         return;
     }
@@ -148,7 +157,7 @@ function addCustomizeChatForm(itemId, resourceName) {
 function addImageViewer(itemId, resourceName) {
 
     if (document.getElementById(itemId)) {
-        let form = document.querySelector('#image-viewer-ui-popup');
+        let portalRoot = document.querySelector('#headlessui-portal-root');
         let main = document.querySelector('body > main');
 
         // yodayo does this by default so I'm just mimicing it
@@ -156,9 +165,19 @@ function addImageViewer(itemId, resourceName) {
         document.documentElement.style.paddingRight = '1px';
 
         // To allow interaction with elements below the form
-        main.setAttribute('inert', '');
+        if (main) {
+            main.setAttribute('inert', '');
+        }
 
-        form.style.display = 'block';
+        if (portalRoot) {
+            portalRoot.style.display = 'block';
+        } else {
+            // Portal root doesn't exist, create new image viewer
+            renderHTMLFromFile(resourceName).then(imageViewerBody => {
+                document.body.appendChild(imageViewerBody);
+                console.log('Image Viewer inserted:', imageViewerBody);
+            });
+        }
 
         return;
     }

--- a/MoescapeCustomUI.user.js
+++ b/MoescapeCustomUI.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Yodayo/ Moescape Customizer
-// @version      Alpha-v31
+// @version      Alpha-v32
 
 // @namespace    MOESCAPE
 


### PR DESCRIPTION
- Simplified both image viewer and chat customizer close functions to consistently remove headlessui-portal-root by ID
- Updated utility functions to properly handle portal root existence checks
- Added proper document style cleanup (overflow, paddingRight) for both modals
- Eliminated complex conditional DOM manipulation that was causing event listener failures
- Ensures modals don't interfere with each other's functionality when opened/closed

Fixes issue where customizer UI event listeners stopped working after closing image viewer.